### PR TITLE
Redstone Bin Fix

### DIFF
--- a/common/src/main/java/bigchadguys/sellingbin/SellingBinInventory.java
+++ b/common/src/main/java/bigchadguys/sellingbin/SellingBinInventory.java
@@ -30,11 +30,11 @@ public class SellingBinInventory implements SidedInventory, INbtSerializable<Nbt
 
     public SellingBinInventory(BlockEntity blockEntity, int slots) {
         this.blockEntity = blockEntity;
-        this.intendedCapacity = slots;
         this.setCapacity(slots);
     }
 
     public void setCapacity(int size) {
+        this.intendedCapacity = size;
         this.availableSlots = IntStream.range(0, size).toArray();
         DefaultedList<ItemStack> oldInventory = this.inventory;
         this.inventory = DefaultedList.ofSize(size, ItemStack.EMPTY);

--- a/common/src/main/java/bigchadguys/sellingbin/SellingBinInventory.java
+++ b/common/src/main/java/bigchadguys/sellingbin/SellingBinInventory.java
@@ -1,5 +1,7 @@
 package bigchadguys.sellingbin;
 
+import bigchadguys.sellingbin.block.BinMode;
+import bigchadguys.sellingbin.block.SellingBinBlock;
 import bigchadguys.sellingbin.data.adapter.Adapters;
 import bigchadguys.sellingbin.data.serializable.INbtSerializable;
 import bigchadguys.sellingbin.init.ModConfigs;
@@ -24,9 +26,11 @@ public class SellingBinInventory implements SidedInventory, INbtSerializable<Nbt
     private final BlockEntity blockEntity;
     private DefaultedList<ItemStack> inventory;
     private int[] availableSlots;
+    private int intendedCapacity;
 
     public SellingBinInventory(BlockEntity blockEntity, int slots) {
         this.blockEntity = blockEntity;
+        this.intendedCapacity = slots;
         this.setCapacity(slots);
     }
 
@@ -221,7 +225,19 @@ public class SellingBinInventory implements SidedInventory, INbtSerializable<Nbt
     public void readNbt(NbtCompound nbt) {
         NbtList inventory = nbt.getList("slots", NbtElement.COMPOUND_TYPE);
         this.inventory = null;
-        this.setCapacity(inventory.size());
+
+        BinMode mode = blockEntity.getCachedState().get(SellingBinBlock.MODE);
+        if(mode == BinMode.BLOCK_BOUND)
+        {
+            this.setCapacity(intendedCapacity);
+        } else
+        {
+            if(mode != BinMode.PLAYER_BOUND)
+            {
+                SellingBinMod.LOGGER.error("Unsupported BinMode {}. Defaulting to PLAYER_BOUND logic", mode.name());
+            }
+            this.setCapacity(inventory.size());
+        }
 
         for(int i = 0; i < this.inventory.size(); i++) {
             NbtCompound entry = inventory.getCompound(i);


### PR DESCRIPTION
Should address Issues #3 and maybe Issue #4, though I haven't tested it.

Block Inventory NBT removes empty slots, so the inventory size becomes incorrect when NBT is read from the block, as opposed to the player. 

This felt like the nicest way to implementing the fix without futzing too much with existing logic. 